### PR TITLE
Fix Tree Reduction Function

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -38,20 +38,20 @@ int main() {
     assert(seqSumTotal == sample); // tested against a standard function
     assert(seqSumTotal == multThreadTotal);
 
-    namespace milliseconds = std::chrono::milliseconds;
+    namespace time = std::chrono;
     std::cout
         << "std::accumulate() ran in "
-        << std::chrono::duration_cast<milliseconds>(accumTime).count()
+        << std::chrono::duration_cast<time::milliseconds>(accumTime).count()
         << " milliseconds\n";
 
     std::cout
         << "SequentialSum() ran in "
-        << std::chrono::duration_cast<milliseconds>(seqTime).count()
+        << std::chrono::duration_cast<time::milliseconds>(seqTime).count()
         << " milliseconds\n";
 
     std::cout
         << "MultiThreadedSum() ran in "
-        << std::chrono::duration_cast<milliseconds>(multTime).count()
+        << std::chrono::duration_cast<time::milliseconds>(multTime).count()
         << " milliseconds\n";
 
     /*

--- a/sum_functions.h
+++ b/sum_functions.h
@@ -1,6 +1,7 @@
 #ifndef SUM_FUNCTIONS_H
 #define SUM_FUNCTIONS_H
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -8,11 +9,11 @@
 
 class Sum {
 public:
-    static int SequentialSum(
+    static std::int64_t SequentialSum(
         const std::vector<int>& values
     );
 
-    static int MultiThreadedSum(
+    static std::int64_t MultiThreadedSum(
         const std::vector<int>& values,
         size_t thread_count
     );


### PR DESCRIPTION
The Tree Reduction function was incorrectly summing up values. 
```c
        for (size_t i = 0; i < end; ++i) {
            partial += values[i];
        }
```
As you can see, I started summing from i = 0, rather than i = start, which refers to the current thread_id chunk. Oops. Well, at least it was a simple fix. Big headache; but simple...
